### PR TITLE
rename `.number()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Radix
 
+# Unreleased (2021-09-28)
+
+- [breaking]: `.number()` method was renamed to `.toString()`;
+
 # 0.3.0 (2021-08-28)
 
 - [improvement]: default `radix` constructor arguments as binary zero;

--- a/README.md
+++ b/README.md
@@ -107,6 +107,35 @@ radix([ 1, 0, 1, 0], 2).asDecimal // -> 10
   ```
 </details>
 
+### Representation
+
+<details>
+  <summary>
+    <code>.toString(radix = 10, sep = "")</code>
+  </summary>
+
+  Constructs a string representation with specified radix and separator.
+
+  ```ts
+  radix([ 1, 0, 1, 0 ], 2).toString()       // -> "10"
+  radix([ 1, 0, 1, 0 ], 2).toString(8)      // -> "12"
+  radix([ 1, 0, 1, 0 ], 2).toString(8, ",") // -> "1,2"
+  ```
+</details>
+
+<details>
+  <summary>
+    <code>.asDecimal</code>
+  </summary>
+
+  Returns the numeric decimal representation.
+
+  ```ts
+  radix([ 1, 0, 1, 0 ], 2).asDecimal // -> 10
+  radix([ 2, 4, 5 ], 8).asDecimal    // -> 165
+  ```
+</details>
+
 ### Properties
 
 <details>
@@ -154,34 +183,7 @@ radix([ 1, 0, 1, 0], 2).asDecimal // -> 10
   ```
 </details>
 
-<details>
-  <summary>
-    <code>.asDecimal</code>
-  </summary>
-
-  Returns the numeric decimal representation.
-
-  ```ts
-  radix([ 1, 0, 1, 0 ], 2).asDecimal // -> 10
-  radix([ 2, 4, 5 ], 8).asDecimal    // -> 165
-  ```
-</details>
-
 ### Manipulations
-
-<details>
-  <summary>
-    <code>.number(radix = 10, sep = "")</code>
-  </summary>
-
-  Constructs a number's string representation with specified radix.
-
-  ```ts
-  radix([ 1, 0, 1, 0 ], 2).number()       // -> "10"
-  radix([ 1, 0, 1, 0 ], 2).number(8)      // -> "12"
-  radix([ 1, 0, 1, 0 ], 2).number(8, ",") // -> "1,2"
-  ```
-</details>
 
 <details>
   <summary>

--- a/src/radix.ts
+++ b/src/radix.ts
@@ -38,9 +38,9 @@ export class Radix {
 	}
 
 	/**
-	 * Constructs a number's string representation with specified radix.
+	 * Constructs a string representation with specified radix.
 	 */
-	number(radix = 10, sep = ""): string {
+	toString(radix = 10, sep = ""): string {
 		return this.setRadix(radix).digits.join(sep);
 	}
 
@@ -48,7 +48,7 @@ export class Radix {
 	 * Returns the numeric decimal representation.
 	 */
 	get asDecimal(): number {
-		return Number(this.number(10));
+		return Number(this.toString(10));
 	}
 
 	/**

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -70,8 +70,8 @@ describe("Transformations", () => {
 		}
 	});
 	it("Transforms into the number", () => {
-		expect(radix([ 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 0 ], 2).number()).toEqual("5962");
-		expect(radix([ 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1 ], 2).number(10, "-")).toEqual("1-1-9-2-7");
+		expect(radix([ 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 0 ], 2).toString()).toEqual("5962");
+		expect(radix([ 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1 ], 2).toString(10, "-")).toEqual("1-1-9-2-7");
 	});
 	it("Changes the rank of the number", () => {
 		expect(radix([ 1, 0, 1 ], 2).setRank().ranks).toEqual([ 1, 0, 0 ]);


### PR DESCRIPTION
Rename `.number()` method to `.toString()` as it better describes what method is doing as it actually returns a string representation of the number.