### PR TITLE
Remove radix aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [breaking]: `.number()` method was renamed to `.toString()`;
 - [feature]: ranks custom decoding options;
+- [breaking]: removed aliases for `.setRadix()` method properties;
 
 # 0.3.0 (2021-08-28)
 

--- a/README.md
+++ b/README.md
@@ -228,23 +228,6 @@ Decoder and decodings can be used simultaniously, at the end of the process each
   radix([ 1, 0, 1, 0 ], 2).setRadix(10) // [ 1, 0 ]
   radix([ 1, 0, 1, 0 ], 2).setRadix(8)  // [ 1, 2 ]
   radix([ 1, 0, 1, 0 ], 2).setRadix(2)  // [ 1, 0, 1, 0 ]
-  
-  // shortcuts
-  radix([ 1, 0 ], 10).binary         // [ 1, 0, 1, 0 ]
-  radix([ 1, 0 ], 10).octal          // [ 1, 2 ]
-  radix([ 1, 0 ], 2).decimal         // [ 2 ]
-  radix([ 1, 0 ], 10).hexadecimal    // [ 10 ]
-  radix([ 1, 2, 3 ], 10).sexagesimal // [ 7, 11 ]
-  ```
-
-  The are also some shortcut properties for most used radix transformations.
-
-  ```ts
-  radix([ 1, 0 ], 10).binary         // [ 1, 0, 1, 0 ]
-  radix([ 1, 0 ], 10).octal          // [ 1, 2 ]
-  radix([ 1, 0 ], 2).decimal         // [ 2 ]
-  radix([ 1, 0 ], 10).hexadecimal    // [ 10 ]
-  radix([ 1, 2, 3 ], 10).sexagesimal // [ 7, 11 ]
   ```
 </details>
 

--- a/src/radix.ts
+++ b/src/radix.ts
@@ -62,41 +62,6 @@ export class Radix {
 	}
 
 	/**
-	 * Returns new `Radix` instance with the binary radix representation.
-	 */
-	get binary(): Radix {
-		return this.setRadix(2);
-	}
-
-	/**
-	 * Returns new `Radix` instance with the octal radix representation.
-	 */
-	get octal(): Radix {
-		return this.setRadix(8);
-	}
-
-	/**
-	 * Returns new `Radix` instance with the decimal radix representation.
-	 */
-	get decimal(): Radix {
-		return this.setRadix(10);
-	}
-
-	/**
-	 * Returns new `Radix` instance with the hexadecimal radix representation.
-	 */
-	get hexadecimal(): Radix {
-		return this.setRadix(16);
-	}
-
-	/**
-	 * Returns new `Radix` instance with the sexagesimal radix representation.
-	 */
-	get sexagesimal(): Radix {
-		return this.setRadix(60);
-	}
-
-	/**
 	 * Changes the value of specific rank and returns the number as new `Radix` instance.
 	 */
 	setRank(value = 0, rank = 0): Radix {

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -75,11 +75,11 @@ describe("Transformations", () => {
 	it("Transforms number's radix", () => {
 		for (const { bases } of numbers) {
 			for (const [ base, digits ] of Object.entries(bases)) {
-				expect(radix(digits, Number(base)).binary.ranks).toEqual(bases[2]);
-				expect(radix(digits, Number(base)).octal.ranks).toEqual(bases[8]);
-				expect(radix(digits, Number(base)).decimal.ranks).toEqual(bases[10]);
-				expect(radix(digits, Number(base)).hexadecimal.ranks).toEqual(bases[16]);
-				expect(radix(digits, Number(base)).sexagesimal.ranks).toEqual(bases[60]);
+				expect(radix(digits, Number(base)).setRadix(2).ranks).toEqual(bases[2]);
+				expect(radix(digits, Number(base)).setRadix(8).ranks).toEqual(bases[8]);
+				expect(radix(digits, Number(base)).setRadix(10).ranks).toEqual(bases[10]);
+				expect(radix(digits, Number(base)).setRadix(16).ranks).toEqual(bases[16]);
+				expect(radix(digits, Number(base)).setRadix(60).ranks).toEqual(bases[60]);
 			}
 		}
 	});


### PR DESCRIPTION
Removed `.setRadix()` method shortcut aliases